### PR TITLE
Support linux

### DIFF
--- a/Formula/go-task.rb
+++ b/Formula/go-task.rb
@@ -1,9 +1,15 @@
 class GoTask < Formula
   desc "Task runner / simpler Make alternative written in Go"
   homepage "https://taskfile.dev"
-  url "https://github.com/go-task/task/releases/download/v2.5.2/task_darwin_amd64.tar.gz"
   version "2.5.2"
-  sha256 "a4ae00e255729aec842261f1dbaaa657d7efa0f97cafc2790d6770d2302cf2e8"
+
+  if OS.mac?
+    url "https://github.com/go-task/task/releases/download/v#{version}/task_darwin_amd64.tar.gz"
+    sha256 "a4ae00e255729aec842261f1dbaaa657d7efa0f97cafc2790d6770d2302cf2e8"
+  elsif OS.linux?
+    url "https://github.com/go-task/task/releases/download/v#{version}/task_linux_amd64.tar.gz"
+    sha256 "d97949bcd590eb01f77f8b10fdce8f5add40864d7a9f7a93bf3916198360734f"
+  end
 
   def install
     bin.install "task"


### PR DESCRIPTION
Homebrew since [2.0.0](https://brew.sh/2019/02/02/homebrew-2.0.0/) release officially supports linux too. 

This PR makes possible installing `task` via `brew` on linux.