### PR TITLE
Update go-task.rb

### DIFF
--- a/Formula/go-task.rb
+++ b/Formula/go-task.rb
@@ -7,7 +7,6 @@ class GoTask < Formula
   homepage "https://taskfile.dev"
   version "v3.9.0"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Apparently `bottle :unneeded` is deprecated:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the go-task/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/go-task/homebrew-tap/Formula/go-task.rb:10
```